### PR TITLE
Updated to use httpd kernel528/httpd:2.4.63-3.22, which is based on k…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/httpd:2.4.63
+FROM kernel528/httpd:2.4.63-3.22
 LABEL authors="kernel528"
 
 COPY httpd-foreground /usr/local/bin/

--- a/VERSION.md
+++ b/VERSION.md
@@ -9,3 +9,4 @@
 * 1.1.2 - Updated badge links in README.md
 * 1.1.3 - Updated to base image kernel528/alpine:3.21.2
 * 1.1.4 - Updated to use kernel528/httpd:2.4.63, which uses base image kernel528/alpine:3.21.3.
+* 1.1.5 - Updated to use kernel528/httpd:2.4.63-3.22, which uses base image kernel528/alpine:3.22.0.

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -25,7 +25,7 @@
             <a href="https://kernel528-starter-node-express-postgresql.onrender.com/">Starter: Node, Express, Postgres</a>
         </nav>
         <p>Version 1.1.4</p>
-        <p>Running: httpd v2.4.63, alpine linux v3.21.3</p>
+        <p>Running: httpd v2.4.63, alpine linux v3.22.0</p>
     </footer>
 </div>
 </body>


### PR DESCRIPTION
…ernel528/alpine:3.22.0.

### Updates
- Updated to use base image of kernel528/httpd:2.4.63-3.22