### PR TITLE
Prepare website 2.2.0 testing release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -51,17 +51,17 @@ steps:
         path: /var/run/docker.sock
     commands:
       - |
-        echo "Smoke testing version $(awk '/^\* /{version=$2} END{print version}' VERSION.md) with kernel528/www.kernelsanders.biz:testing-latest"
-      - docker run --rm -d -p 8082:80 --name site-test kernel528/www.kernelsanders.biz:testing-latest
+        echo "Smoke testing version $(awk '/^\* /{version=$2} END{print version}' VERSION.md) with kernel528/www.kernelsanders.biz:testing-${DRONE_COMMIT:0:8}-drone-build-${DRONE_BUILD_NUMBER}"
+      - docker run --rm -d --name site-test-${DRONE_BUILD_NUMBER} kernel528/www.kernelsanders.biz:testing-${DRONE_COMMIT:0:8}-drone-build-${DRONE_BUILD_NUMBER}
       - |
         for _ in $(seq 1 15); do
-          if docker run --rm --network container:site-test curlimages/curl:8.7.1 -f http://localhost/; then
+          if docker run --rm --network container:site-test-${DRONE_BUILD_NUMBER} curlimages/curl:8.7.1 -f http://localhost/; then
             exit 0
           fi
           sleep 1
         done
         exit 1
-      - docker stop site-test
+      - docker stop site-test-${DRONE_BUILD_NUMBER}
   - name: smoke-test-cleanup
     image: docker:27-cli
     volumes:
@@ -74,7 +74,7 @@ steps:
     commands:
       - |
         echo "Cleaning up smoke test container for version $(awk '/^\* /{version=$2} END{print version}' VERSION.md)"
-      - docker rm -f site-test || true
+      - docker rm -f site-test-${DRONE_BUILD_NUMBER} || true
 
   # Post slack notification
   - name: slack-notification

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,12 @@ version: 2
 updates:
   - package-ecosystem: "docker" # See documentation for possible values
     directory: "/" # Location of package manifests
+    target-branch: "testing"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "testing"
     schedule:
       interval: "weekly"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,19 +7,26 @@
 - Keep changes focused.
 - Do not make broad refactors without asking.
 - Run the smallest relevant test/build first.
-- At session close, update `ai-handoff.md`.
+- At session close, record validation and remaining release/deployment steps in the PR or handoff notes when present.
 
 ## Scope
 - `htdocs/` is the site source.
 - `Dockerfile`, `httpd-foreground`, and `VERSION.md` control the image build and release versioning.
 
 ## Workflow
-- Start work from `testing`.
+- Treat `testing` as the policy branch and start working branches from current `origin/testing`.
+- Merge working branches into `testing` only after local checks and the Drone testing pipeline pass.
+- After `testing` is validated, open a PR from `testing` to `main`.
+- Create release tags only from merged `main`; do not use testing images for Swarm deployment.
 - Keep version bumps consistent across `VERSION.md` and any hardcoded runtime text in `htdocs/index.html`.
 - Update the base image and release notes together.
+- After the release image resolves, update `docker-swarm/stacks/kernelsanders-stack.yml`; deployment is performed through the Portainer UI.
 
 ## Validation
+- `npm ci`
+- `npm audit`
 - `npm run lint`
+- Build the release candidate image and verify the homepage from a disposable container.
 
 ## Style
 - Use 4-space indentation.
@@ -29,4 +36,5 @@
 ## PRs
 - Commit messages should be short and descriptive.
 - PRs should mention version bumps and UI screenshots when relevant.
+- Dependabot version PRs should target `testing`; retarget security PRs from `main` to `testing` before merge.
 - Drone handles CI and publishing.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,8 +2,10 @@
 
 - Static site repo for `www.kernelsanders.biz`.
 - Current release: `2.1.1`.
-- Base image: `kernel528/httpd:2.4.68-3.24.1`.
+- Planned release: `2.2.0` from `testing`, then `main`.
+- Release-candidate base image: `kernel528/httpd:2.4.68-3.24.1_1`.
 - Deployed stack image: `kernel528/www.kernelsanders.biz:2.1.1` on host port `81`.
 - Key files: `htdocs/index.html`, `htdocs/style.css`, `Dockerfile`, `VERSION.md`, `scripts/inject-version.sh`, `httpd-foreground`, `.drone.yml`.
-- CI: `testing` lint/build/smoke test with `docker:27-cli`; `main` publishes tagged releases.
+- CI: PRs into `testing` run lint/build/smoke tests with isolated build-specific containers; tags from `main` publish releases.
+- Deployment: update `docker-swarm/stacks/kernelsanders-stack.yml` after release, then redeploy through Portainer UI.
 - Update `VERSION.md`, `Dockerfile`, and hardcoded runtime text together on base-image bumps.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/httpd:2.4.68-3.24.1
+FROM kernel528/httpd:2.4.68-3.24.1_1
 LABEL authors="kernel528"
 
 COPY VERSION.md /tmp/VERSION.md

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This repo contains the source code for the www.kernelsanders.biz static website and its Docker image.
 
 ## Setup
-* This uses the `kernel528/httpd:2.4.68-3.24.1` image as the base Docker image.
+* This uses the `kernel528/httpd:2.4.68-3.24.1_1` image as the base Docker image.
 * Site content is located in `./htdocs`.
 * The Dockerfile copies `htdocs/` into the Apache web root and injects the site version during build.
 * Drone builds and smoke-tests temporary images for pull requests targeting `testing`.
@@ -18,14 +18,17 @@ This repo contains the source code for the www.kernelsanders.biz static website 
 
 This website repository is an independent downstream of [`httpd-docker`](https://github.com/kernel528/httpd-docker). It is coordinated by [`docker-workspace`](https://github.com/kernel528/docker-workspace), publishes `kernel528/www.kernelsanders.biz`, and is deployed by [`docker-swarm`](https://github.com/kernel528/docker-swarm) through `stacks/kernelsanders-stack.yml`.
 
-When a new immutable `kernel528/httpd` tag is published and validated:
+The repository policy branch is `testing`. When a new immutable `kernel528/httpd` tag is published and validated:
 
-1. Create a separate website refresh branch.
+1. Sync `testing` and create a focused working branch from it.
 2. Update the `FROM kernel528/httpd:<tag>` line in `Dockerfile`.
-3. Update `VERSION.md` and any release-tag references.
+3. Update `VERSION.md`, documentation, dependency locks, and CI configuration as needed.
 4. Run lint, build the image, and smoke-test the rendered homepage.
-5. Merge and publish an immutable website release tag.
-6. Only then update `kernelsanders-stack.yml`, deploy the website stack, and verify the site.
+5. Open a PR into `testing`; require the testing lint/build/smoke pipeline to pass before merge.
+6. After `testing` is validated, open a PR from `testing` to `main`.
+7. Create the immutable release tag from merged `main` and confirm the exact Docker image tag resolves.
+8. Update `kernelsanders-stack.yml` in the independent `docker-swarm` repository.
+9. Redeploy the stack from the Portainer UI, then verify the service, logs, and website.
 
 Do not combine the HTTPD image release, website release, and Swarm manifest update into one repository or commit.
 
@@ -49,6 +52,7 @@ Do not combine the HTTPD image release, website release, and Swarm manifest upda
 ## CI Behavior
 * `testing` pipeline runs on pull requests to the `testing` branch and runs linting, builds testing images, and smoke tests.
 * `main` pipeline runs on tags from the `main` branch and builds the release images.
+* Dependabot version updates target `testing`. GitHub security updates may still target the default branch; retarget them to `testing` before merging.
 
 ## How to Build Locally and Push
 * Build the Docker image:
@@ -57,8 +61,12 @@ Do not combine the HTTPD image release, website release, and Swarm manifest upda
     * `docker image push kernel528/www.kernelsanders.biz:<version>`
 
 ## Release Checklist
+* Start from current `testing` and merge the validated working branch into `testing` first.
 * Update the base image in `Dockerfile` if needed.
 * Bump the version and notes in `VERSION.md`.
-* Ensure the footer version in `htdocs/index.html` matches `VERSION.md` (injected at build time).
+* Run `npm ci`, `npm audit`, `npm run lint`, the Docker build, and a homepage smoke test.
+* Merge `testing` into `main`, then create the release tag from `main`.
+* Confirm the release image resolves before changing the Swarm stack.
+* Update and merge `kernelsanders-stack.yml`, then redeploy from Portainer and validate the site.
 
 ### Author:  kernel528@gmail.com

--- a/VERSION.md
+++ b/VERSION.md
@@ -23,3 +23,4 @@
 * 2.0.6 - Updated base image to kernel528/httpd:2.4.66-3.23.3 and refreshed documentation.
 * 2.1.0 - Updated base image to kernel528/httpd:2.4.68-3.24.1.
 * 2.1.1 - Release created after Drone smoke-test version logging and YAML fixes.
+* 2.2.0 - Updated to kernel528/httpd:2.4.68-3.24.1_1, refreshed npm security dependencies, and isolated Drone smoke tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "www.kernelsanders.biz",
       "devDependencies": {
         "htmlhint": "^1.2.0",
         "http-server": "^14.1.1",
@@ -276,9 +277,9 @@
       "license": "MIT"
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -369,9 +370,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1560,9 +1561,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1692,9 +1693,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1719,9 +1720,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -1739,7 +1740,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
- rebase the website image on kernel528/httpd:2.4.68-3.24.1_1
- set the planned website release to 2.2.0
- apply remaining npm audit lockfile fixes after Dependabot PRs #60-#65
- route Dependabot version updates through testing and document security-PR retargeting
- isolate Drone smoke tests by build image and container name to prevent concurrent PR collisions
- document testing -> main -> tag -> docker-swarm -> Portainer deployment flow

## Validation
- npm ci
- npm audit: 0 vulnerabilities
- npm run lint
- drone lint --trusted .drone.yml
- linux/amd64 Docker build with --pull --no-cache
- Apache 2.4.68 runtime check
- homepage curl and injected Site Version 2.2.0/style.css?v=2.2.0 checks

## Release Gate
Merge into testing only after Drone passes. Then open testing -> main, create tag 2.2.0 from main, verify the Docker image, and only then update docker-swarm/stacks/kernelsanders-stack.yml for Portainer redeployment.