### PR TITLE
Release website 2.2.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -51,17 +51,17 @@ steps:
         path: /var/run/docker.sock
     commands:
       - |
-        echo "Smoke testing version $(awk '/^\* /{version=$2} END{print version}' VERSION.md) with kernel528/www.kernelsanders.biz:testing-latest"
-      - docker run --rm -d -p 8082:80 --name site-test kernel528/www.kernelsanders.biz:testing-latest
+        echo "Smoke testing version $(awk '/^\* /{version=$2} END{print version}' VERSION.md) with kernel528/www.kernelsanders.biz:testing-${DRONE_COMMIT:0:8}-drone-build-${DRONE_BUILD_NUMBER}"
+      - docker run --rm -d --name site-test-${DRONE_BUILD_NUMBER} kernel528/www.kernelsanders.biz:testing-${DRONE_COMMIT:0:8}-drone-build-${DRONE_BUILD_NUMBER}
       - |
         for _ in $(seq 1 15); do
-          if docker run --rm --network container:site-test curlimages/curl:8.7.1 -f http://localhost/; then
+          if docker run --rm --network container:site-test-${DRONE_BUILD_NUMBER} curlimages/curl:8.7.1 -f http://localhost/; then
             exit 0
           fi
           sleep 1
         done
         exit 1
-      - docker stop site-test
+      - docker stop site-test-${DRONE_BUILD_NUMBER}
   - name: smoke-test-cleanup
     image: docker:27-cli
     volumes:
@@ -74,7 +74,7 @@ steps:
     commands:
       - |
         echo "Cleaning up smoke test container for version $(awk '/^\* /{version=$2} END{print version}' VERSION.md)"
-      - docker rm -f site-test || true
+      - docker rm -f site-test-${DRONE_BUILD_NUMBER} || true
 
   # Post slack notification
   - name: slack-notification

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,12 @@ version: 2
 updates:
   - package-ecosystem: "docker" # See documentation for possible values
     directory: "/" # Location of package manifests
+    target-branch: "testing"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "testing"
     schedule:
       interval: "weekly"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,19 +7,26 @@
 - Keep changes focused.
 - Do not make broad refactors without asking.
 - Run the smallest relevant test/build first.
-- At session close, update `ai-handoff.md`.
+- At session close, record validation and remaining release/deployment steps in the PR or handoff notes when present.
 
 ## Scope
 - `htdocs/` is the site source.
 - `Dockerfile`, `httpd-foreground`, and `VERSION.md` control the image build and release versioning.
 
 ## Workflow
-- Start work from `testing`.
+- Treat `testing` as the policy branch and start working branches from current `origin/testing`.
+- Merge working branches into `testing` only after local checks and the Drone testing pipeline pass.
+- After `testing` is validated, open a PR from `testing` to `main`.
+- Create release tags only from merged `main`; do not use testing images for Swarm deployment.
 - Keep version bumps consistent across `VERSION.md` and any hardcoded runtime text in `htdocs/index.html`.
 - Update the base image and release notes together.
+- After the release image resolves, update `docker-swarm/stacks/kernelsanders-stack.yml`; deployment is performed through the Portainer UI.
 
 ## Validation
+- `npm ci`
+- `npm audit`
 - `npm run lint`
+- Build the release candidate image and verify the homepage from a disposable container.
 
 ## Style
 - Use 4-space indentation.
@@ -29,4 +36,5 @@
 ## PRs
 - Commit messages should be short and descriptive.
 - PRs should mention version bumps and UI screenshots when relevant.
+- Dependabot version PRs should target `testing`; retarget security PRs from `main` to `testing` before merge.
 - Drone handles CI and publishing.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,8 +2,10 @@
 
 - Static site repo for `www.kernelsanders.biz`.
 - Current release: `2.1.1`.
-- Base image: `kernel528/httpd:2.4.68-3.24.1`.
+- Planned release: `2.2.0` from `testing`, then `main`.
+- Release-candidate base image: `kernel528/httpd:2.4.68-3.24.1_1`.
 - Deployed stack image: `kernel528/www.kernelsanders.biz:2.1.1` on host port `81`.
 - Key files: `htdocs/index.html`, `htdocs/style.css`, `Dockerfile`, `VERSION.md`, `scripts/inject-version.sh`, `httpd-foreground`, `.drone.yml`.
-- CI: `testing` lint/build/smoke test with `docker:27-cli`; `main` publishes tagged releases.
+- CI: PRs into `testing` run lint/build/smoke tests with isolated build-specific containers; tags from `main` publish releases.
+- Deployment: update `docker-swarm/stacks/kernelsanders-stack.yml` after release, then redeploy through Portainer UI.
 - Update `VERSION.md`, `Dockerfile`, and hardcoded runtime text together on base-image bumps.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/httpd:2.4.68-3.24.1
+FROM kernel528/httpd:2.4.68-3.24.1_1
 LABEL authors="kernel528"
 
 COPY VERSION.md /tmp/VERSION.md

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This repo contains the source code for the www.kernelsanders.biz static website and its Docker image.
 
 ## Setup
-* This uses the `kernel528/httpd:2.4.68-3.24.1` image as the base Docker image.
+* This uses the `kernel528/httpd:2.4.68-3.24.1_1` image as the base Docker image.
 * Site content is located in `./htdocs`.
 * The Dockerfile copies `htdocs/` into the Apache web root and injects the site version during build.
 * Drone builds and smoke-tests temporary images for pull requests targeting `testing`.
@@ -18,14 +18,17 @@ This repo contains the source code for the www.kernelsanders.biz static website 
 
 This website repository is an independent downstream of [`httpd-docker`](https://github.com/kernel528/httpd-docker). It is coordinated by [`docker-workspace`](https://github.com/kernel528/docker-workspace), publishes `kernel528/www.kernelsanders.biz`, and is deployed by [`docker-swarm`](https://github.com/kernel528/docker-swarm) through `stacks/kernelsanders-stack.yml`.
 
-When a new immutable `kernel528/httpd` tag is published and validated:
+The repository policy branch is `testing`. When a new immutable `kernel528/httpd` tag is published and validated:
 
-1. Create a separate website refresh branch.
+1. Sync `testing` and create a focused working branch from it.
 2. Update the `FROM kernel528/httpd:<tag>` line in `Dockerfile`.
-3. Update `VERSION.md` and any release-tag references.
+3. Update `VERSION.md`, documentation, dependency locks, and CI configuration as needed.
 4. Run lint, build the image, and smoke-test the rendered homepage.
-5. Merge and publish an immutable website release tag.
-6. Only then update `kernelsanders-stack.yml`, deploy the website stack, and verify the site.
+5. Open a PR into `testing`; require the testing lint/build/smoke pipeline to pass before merge.
+6. After `testing` is validated, open a PR from `testing` to `main`.
+7. Create the immutable release tag from merged `main` and confirm the exact Docker image tag resolves.
+8. Update `kernelsanders-stack.yml` in the independent `docker-swarm` repository.
+9. Redeploy the stack from the Portainer UI, then verify the service, logs, and website.
 
 Do not combine the HTTPD image release, website release, and Swarm manifest update into one repository or commit.
 
@@ -49,6 +52,7 @@ Do not combine the HTTPD image release, website release, and Swarm manifest upda
 ## CI Behavior
 * `testing` pipeline runs on pull requests to the `testing` branch and runs linting, builds testing images, and smoke tests.
 * `main` pipeline runs on tags from the `main` branch and builds the release images.
+* Dependabot version updates target `testing`. GitHub security updates may still target the default branch; retarget them to `testing` before merging.
 
 ## How to Build Locally and Push
 * Build the Docker image:
@@ -57,8 +61,12 @@ Do not combine the HTTPD image release, website release, and Swarm manifest upda
     * `docker image push kernel528/www.kernelsanders.biz:<version>`
 
 ## Release Checklist
+* Start from current `testing` and merge the validated working branch into `testing` first.
 * Update the base image in `Dockerfile` if needed.
 * Bump the version and notes in `VERSION.md`.
-* Ensure the footer version in `htdocs/index.html` matches `VERSION.md` (injected at build time).
+* Run `npm ci`, `npm audit`, `npm run lint`, the Docker build, and a homepage smoke test.
+* Merge `testing` into `main`, then create the release tag from `main`.
+* Confirm the release image resolves before changing the Swarm stack.
+* Update and merge `kernelsanders-stack.yml`, then redeploy from Portainer and validate the site.
 
 ### Author:  kernel528@gmail.com

--- a/VERSION.md
+++ b/VERSION.md
@@ -23,3 +23,4 @@
 * 2.0.6 - Updated base image to kernel528/httpd:2.4.66-3.23.3 and refreshed documentation.
 * 2.1.0 - Updated base image to kernel528/httpd:2.4.68-3.24.1.
 * 2.1.1 - Release created after Drone smoke-test version logging and YAML fixes.
+* 2.2.0 - Updated to kernel528/httpd:2.4.68-3.24.1_1, refreshed npm security dependencies, and isolated Drone smoke tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "www.kernelsanders.biz",
       "devDependencies": {
         "htmlhint": "^1.2.0",
         "http-server": "^14.1.1",
@@ -276,9 +277,9 @@
       "license": "MIT"
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -369,9 +370,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1560,9 +1561,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1692,9 +1693,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1719,9 +1720,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -1739,7 +1740,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -808,9 +808,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,9 +685,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1060,9 +1060,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1799,13 +1799,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1919,15 +1920,15 @@
       "license": "MIT"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1939,14 +1940,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1507,9 +1507,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.7.tgz",
+      "integrity": "sha512-V+1uQNdzybxa14e/p00HZnQNNcTjnRJjDxg2V8wtkjFctq4M7hXFws4oekyTP0Jebeq7QYtpFyOeBAjc88zvYg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1341,10 +1341,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
## Summary
Promote the validated testing branch to main for the 2.2.0 release.

- kernel528/httpd:2.4.68-3.24.1_1 base
- merged Dependabot security updates plus remaining npm audit fixes
- npm audit reports 0 vulnerabilities
- collision-free Drone testing smoke jobs
- documented testing -> main -> tag -> Swarm -> Portainer release flow

## Validation
- testing PR #71 passed Drone build and smoke tests
- local npm ci, npm audit, and npm run lint passed
- local linux/amd64 image build used --pull --no-cache
- Apache and rendered homepage smoke tests passed

## After Merge
Create GitHub release tag 2.2.0 from main. Confirm kernel528/www.kernelsanders.biz:2.2.0 resolves before updating docker-swarm.